### PR TITLE
feat: adding internal user deletion

### DIFF
--- a/lib/v0/index.js
+++ b/lib/v0/index.js
@@ -118,7 +118,6 @@ class V0 extends Auth {
   deleteInternalUser(opts) {
     return this.send('DELETE', `/users/internal`, opts);
   }
-  
 
   /**
    * Schedule user account deletion

--- a/lib/v0/index.js
+++ b/lib/v0/index.js
@@ -112,6 +112,15 @@ class V0 extends Auth {
   }
 
   /**
+   * Deletes a user by basic token
+   * @param {TinaSendOpts} opts
+   */
+  deleteInternalUser(opts) {
+    return this.send('DELETE', `/users/internal`, opts);
+  }
+  
+
+  /**
    * Schedule user account deletion
    * @param {TinaSendOpts} opts
    */


### PR DESCRIPTION
For GDPR purpose timekeeper will call the delete method after 30 days.
This will work with basic token and query parameters.